### PR TITLE
typo correction

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -74,8 +74,8 @@ def main():
             norient=int(a[1:])
             print('Use %d orientations'%(norient))
         elif o in ("-m", "--mask"):
-            imask=np.load(a[1:])
-            print('Use %s mask'%(a[1:]))
+            imask=np.load(a)
+            print('Use %s mask'%(a))
         elif o in ("-p", "--path"):
             outpath=a[1:]
         else:


### PR DESCRIPTION
if mask is loaded from .npy file, "a" is the file name so there's no need for "a[1:]"  ?